### PR TITLE
feat: add target blank to apply link so they open in new tab

### DIFF
--- a/.github/scripts/add_listing.py
+++ b/.github/scripts/add_listing.py
@@ -100,7 +100,7 @@ def format_row(fields, table_type):
     date = datetime.now().strftime('%b %-d')
 
     apply_btn = (
-        f'<a href="{apply_link}">'
+        f'<a href="{apply_link}" target="_blank" rel="noopener noreferrer">'
         f'<img src="https://i.imgur.com/u1KNU8z.png" width="118" alt="Apply">'
         f'</a>'
     )

--- a/.github/scripts/auto_approve.py
+++ b/.github/scripts/auto_approve.py
@@ -138,7 +138,7 @@ def format_row(fields, table_type):
     date = datetime.now().strftime('%b %-d')
 
     apply_btn = (
-        f'<a href="{apply_link}">'
+        f'<a href="{apply_link}" target="_blank" rel="noopener noreferrer">'
         f'<img src="https://i.imgur.com/u1KNU8z.png" width="118" alt="Apply">'
         f'</a>'
     )

--- a/.github/scripts/process_approved.py
+++ b/.github/scripts/process_approved.py
@@ -147,7 +147,7 @@ def format_row(fields, table_type):
     date = datetime.now().strftime('%b %-d')
 
     apply_btn = (
-        f'<a href="{apply_link}">'
+        f'<a href="{apply_link}" target="_blank" rel="noopener noreferrer">'
         f'<img src="https://i.imgur.com/u1KNU8z.png" width="118" alt="Apply">'
         f'</a>'
     )


### PR DESCRIPTION
## Description

Found it a bit annoying when clicking on Apply button and links not opening on new page. This was a problem when applying to jobs on my phone.
---

## Type of Change

Updated scripts to include target="_blank" allowing links to open in new tab.

---

## Checklist

### Formatting
- [ ] Table row follows the correct column order: `Company | Role | Location | Application/Link | Date Posted`
- [ ] Company column is **plain text** (no hyperlink)
- [ ] Apply button uses the correct HTML image format: `<a href="URL"><img src="https://i.imgur.com/u1KNU8z.png" width="118" alt="Apply"></a>`
- [ ] Closed roles show 🔒 in the Application/Link column (not a dead link)
- [ ] Date Posted is in `Mon DD` format (e.g. `Jul 5`)
- [ ] Sponsorship flags (🛂, 🇺🇸) are appended to the role title where applicable
- [ ] Multiple roles at same company use `↳` in the Company column

### Scope
- [ ] The role is in the **United States, Canada, or is Remote** — no international-only roles

### Links
- [ ] The apply link goes directly to the job posting (not just the careers homepage)
- [ ] The posting is publicly accessible without requiring a login

### Duplicates & Order
- [ ] I checked that this listing does not already exist in the file
- [ ] New entries are inserted in **alphabetical order** by company name

---

## Notes for Reviewer

<!-- Anything else the reviewer should know? Leave blank if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Application links now open in a new browser tab.
  * Enhanced link security when opening external pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->