### PR TITLE
feat: infer education level from job title in auto-discovered listings

### DIFF
--- a/.github/scripts/scrape_jobs.py
+++ b/.github/scripts/scrape_jobs.py
@@ -352,6 +352,15 @@ def infer_listing_type(title):
         return 'Internship', 'Summer 2026'
     return 'Internship', 'Summer 2027'
 
+def infer_education_level(title):
+    t = title.lower()
+    if any(kw in t for kw in ['phd', 'phd student', 'phd intern', 'phd research', 'phd early career']):
+        return 'PhD'
+    if any(kw in t for kw in ['master', 'ms ', 'm.s.', 'masters']):
+        return "Master's"
+    # Default to Undergrad
+    return 'Undergrad'
+
 
 def scrape_greenhouse(company, slug):
     url = f'https://boards-api.greenhouse.io/v1/boards/{slug}/jobs?content=true'
@@ -873,7 +882,7 @@ No
 
 ### Education Level
 
-Undergrad
+{infer_education_level(job['title'])}
 
 ### Direct Application Link
 


### PR DESCRIPTION
- Add infer_education_level() function to detect PhD, Master's, and Undergrad roles from job titles
- Update scrape_jobs.py issue template to use inferred education level instead of hardcoded 'Undergrad'
- Checks for PhD keywords: phd, phd student, phd intern, phd research, phd early career
- Checks for Master's keywords: master, ms, m.s., masters
- Defaults to Undergrad if no graduate-level keywords found

Fixes issue where PhD and Master's positions were incorrectly labeled as Undergrad

## Description

<!-- Briefly describe what this PR changes. Examples:
  - Add [Company] [Role] to Summer 2027 internships
  - Mark [Company] as closed (🔒)
  - Fix broken apply link for [Company]
  - Remove expired listings from Fall 2027
-->

---

## Type of Change

- [ ] Add new job listing(s)
- [ ] Mark role(s) as closed (🔒)
- [ ] Fix broken link(s)
- [ ] Remove expired listing(s)
- [ ] Update documentation
- [ ] Other (describe below)

---

## Checklist

### Formatting
- [ ] Table row follows the correct column order: `Company | Role | Location | Application/Link | Date Posted`
- [ ] Company column is **plain text** (no hyperlink)
- [ ] Apply button uses the correct HTML image format: `<a href="URL"><img src="https://i.imgur.com/u1KNU8z.png" width="118" alt="Apply"></a>`
- [ ] Closed roles show 🔒 in the Application/Link column (not a dead link)
- [ ] Date Posted is in `Mon DD` format (e.g. `Jul 5`)
- [ ] Sponsorship flags (🛂, 🇺🇸) are appended to the role title where applicable
- [ ] Multiple roles at same company use `↳` in the Company column

### Scope
- [ ] The role is in the **United States, Canada, or is Remote** — no international-only roles

### Links
- [ ] The apply link goes directly to the job posting (not just the careers homepage)
- [ ] The posting is publicly accessible without requiring a login

### Duplicates & Order
- [ ] I checked that this listing does not already exist in the file
- [ ] New entries are inserted in **alphabetical order** by company name

---

## Notes for Reviewer

<!-- Anything else the reviewer should know? Leave blank if not applicable. -->
