### PR TITLE
Add priority-company alert bot for new roles

### DIFF
--- a/.github/data/priority_companies.json
+++ b/.github/data/priority_companies.json
@@ -1,0 +1,16 @@
+[
+  "Amazon",
+  "Apple",
+  "Databricks",
+  "Google",
+  "Meta",
+  "Microsoft",
+  "NVIDIA",
+  "OpenAI",
+  "Palantir",
+  "Salesforce",
+  "SpaceX",
+  "Stripe",
+  "Tesla",
+  "Waymo"
+]

--- a/.github/scripts/scrape_jobs.py
+++ b/.github/scripts/scrape_jobs.py
@@ -13,6 +13,7 @@ from pathlib import Path
 SEEN_JOBS_FILE = Path('.github/data/seen_jobs.json')
 TITLE_CACHE_FILE = Path('.github/data/title_classifications.json')
 GEMINI_USAGE_FILE = Path('.github/data/gemini_usage.json')
+PRIORITY_COMPANIES_FILE = Path('.github/data/priority_companies.json')
 
 GEMINI_DAILY_LIMIT = 1400
 GEMINI_RPM_DELAY = 4.2
@@ -22,6 +23,23 @@ _title_cache = None
 _confidence_cache = {}
 _gemini_calls_today = 0
 _gemini_usage_date = None
+
+DEFAULT_PRIORITY_COMPANIES = [
+    'Amazon',
+    'Apple',
+    'Databricks',
+    'Google',
+    'Meta',
+    'Microsoft',
+    'NVIDIA',
+    'OpenAI',
+    'Palantir',
+    'Salesforce',
+    'SpaceX',
+    'Stripe',
+    'Tesla',
+    'Waymo',
+]
 
 BOUNDARY_KEYWORDS = [r'\bintern\b', r'\binternship\b', r'\bco-op\b', r'\bcoop\b', r'\bjunior\b',
                      r'\bphd\b', r'\bgraduate\b', r'\bms intern\b',
@@ -385,6 +403,53 @@ def save_seen_jobs(seen):
     SEEN_JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(SEEN_JOBS_FILE, 'w') as f:
         json.dump(sorted(list(seen)), f, indent=2)
+
+
+def normalize_company_name(name):
+    return re.sub(r'[^a-z0-9]+', '', name.lower())
+
+
+def load_priority_companies():
+    try:
+        if PRIORITY_COMPANIES_FILE.exists():
+            with open(PRIORITY_COMPANIES_FILE) as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                loaded = {
+                    normalize_company_name(c)
+                    for c in data
+                    if isinstance(c, str) and c.strip()
+                }
+                if loaded:
+                    return loaded
+            print('  [priority] Invalid priority_companies.json, using defaults')
+    except Exception as e:
+        print(f'  [priority] Failed to load priority companies file: {e}')
+    return {normalize_company_name(c) for c in DEFAULT_PRIORITY_COMPANIES}
+
+
+def is_priority_company(company, priority_companies):
+    return normalize_company_name(company) in priority_companies
+
+
+def send_priority_webhook_alert(job):
+    webhook_url = os.environ.get('PRIORITY_ALERT_WEBHOOK_URL', '').strip()
+    if not webhook_url:
+        return
+
+    message = (
+        f'🚨 Priority company role detected: {job["company"]} — {job["title"]}\n'
+        f'Location: {job["location"]}\n'
+        f'Apply: {job["url"]}'
+    )
+    payload = {'content': message} if 'discord.com/api/webhooks' in webhook_url else {'text': message}
+
+    try:
+        resp = requests.post(webhook_url, json=payload, timeout=10)
+        if resp.status_code not in (200, 201, 202, 204):
+            print(f'  [priority] webhook failed ({resp.status_code}): {resp.text[:200]}')
+    except Exception as e:
+        print(f'  [priority] webhook error: {e}')
 
 
 def is_tech_title_keywords(title):
@@ -1062,10 +1127,11 @@ def scrape_amazon():
 
 
 
-def create_github_issue(job, token, repo):
+def create_github_issue(job, token, repo, priority=False):
     listing_type, season = infer_listing_type(job['title'])
     confident = job.get('confident', False)
-    issue_title = f'[JOB] {job["company"]} — {job["title"]}'
+    issue_prefix = '[PRIORITY ALERT] ' if priority else ''
+    issue_title = f'{issue_prefix}[JOB] {job["company"]} — {job["title"]}'
 
     if confident:
         labels = ['new listing', 'auto-discovered']
@@ -1077,6 +1143,8 @@ def create_github_issue(job, token, repo):
             f'**Needs manual review** — Gemini was unavailable so this was classified by keyword matching only. '
             f'Please verify this is a legitimate tech role before approving.'
         )
+    if priority:
+        notes = f'🚨 **Priority company alert**\n\n{notes}'
 
     body = f"""### Company Name
 
@@ -1150,6 +1218,38 @@ _No response_
         print(f'  Failed ({resp.status_code}): {resp.text[:200]}')
 
 
+def create_priority_alert_issue(job, token, repo):
+    issue_title = f'🚨 [PRIORITY ALERT] {job["company"]} — {job["title"]}'
+    body = f"""A new role from a priority company was auto-discovered.
+
+- **Company:** {job['company']}
+- **Role:** {job['title']}
+- **Location:** {job['location']}
+- **Apply:** {job['url']}
+- **Source:** {job['board']}
+- **Confidence:** {"High" if job.get('confident') else "Needs review"}
+
+Apply quickly if relevant.
+"""
+    headers = {
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github.v3+json',
+    }
+    resp = requests.post(
+        f'https://api.github.com/repos/{repo}/issues',
+        json={
+            'title': issue_title,
+            'body': body,
+        },
+        headers=headers,
+        timeout=10,
+    )
+    if resp.status_code == 201:
+        print(f'  [priority] Created alert issue: {issue_title}')
+    else:
+        print(f'  [priority] Failed to create alert issue ({resp.status_code}): {resp.text[:200]}')
+
+
 def main():
     load_gemini_usage()
 
@@ -1161,6 +1261,7 @@ def main():
         return
 
     seen = load_seen_jobs()
+    priority_companies = load_priority_companies()
 
     candidate_jobs = []
 
@@ -1264,6 +1365,12 @@ def main():
 
         for job in high_confidence:
             add_job_directly(job, listings_file, readme_file)
+            if is_priority_company(job['company'], priority_companies):
+                send_priority_webhook_alert(job)
+                if token and repo:
+                    create_priority_alert_issue(job, token, repo)
+                else:
+                    print(f'  [priority] {job["company"]}: {job["title"]} | {job["location"]} | {job["url"]}')
             time.sleep(0.5)
 
         if low_confidence:
@@ -1274,7 +1381,10 @@ def main():
             else:
                 for job in low_confidence:
                     try:
-                        create_github_issue(job, token, repo)
+                        priority = is_priority_company(job['company'], priority_companies)
+                        if priority:
+                            send_priority_webhook_alert(job)
+                        create_github_issue(job, token, repo, priority=priority)
                     except Exception as e:
                         print(f'  [issue] Failed to create issue for "{job["title"]}": {e}')
                     time.sleep(1)

--- a/.github/workflows/scrape-jobs.yml
+++ b/.github/workflows/scrape-jobs.yml
@@ -35,12 +35,13 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+          PRIORITY_ALERT_WEBHOOK_URL: ${{ secrets.PRIORITY_ALERT_WEBHOOK_URL }}
         run: python .github/scripts/scrape_jobs.py
 
       - name: Commit changes
         run: |
           git config user.name "Aprameya Kannan"
           git config user.email "aprameyakannan@gmail.com"
-          git add .github/data/seen_jobs.json .github/data/title_classifications.json .github/data/gemini_usage.json listings.json README.md
+          git add .github/data/seen_jobs.json .github/data/title_classifications.json .github/data/gemini_usage.json .github/data/priority_companies.json listings.json README.md
           git diff --staged --quiet || git commit -m "add auto-discovered listings and update scraper data"
           git pull --rebase -X ours && git push

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Use this repo to share and keep track of tech internships and new grad roles for
 
 ---
 
+## Priority company alerts
+
+The scraper can send immediate alerts when it finds new roles from bigger-name companies.
+
+1. Edit `.github/data/priority_companies.json` with the companies you want to track.
+2. Add a `PRIORITY_ALERT_WEBHOOK_URL` repository secret (Slack/Discord-compatible webhook).
+3. The scraper will post a dedicated priority alert issue and send a webhook message whenever a new matching role is found.
+
+---
+
 ## ☀️ Summer 2027 Internships
 
 <!-- TABLE_START summer -->


### PR DESCRIPTION
Summary:\n- Add configurable priority company list in .github/data/priority_companies.json\n- Detect new jobs from priority companies in scrape_jobs.py\n- Send immediate webhook alerts using PRIORITY_ALERT_WEBHOOK_URL\n- Create dedicated priority alert issues for priority matches\n- Prefix priority low-confidence auto-discovered issues\n- Wire secret in scrape-jobs workflow and document setup in README\n\nNote: branch is pushed from fork because this account cannot push directly to upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added priority-company detection for newly discovered job postings.
  * Added configurable priority-company tracking, including a default list of leading technology companies.
  * Added optional immediate alerts through Slack- or Discord-compatible webhooks.
  * Priority roles now receive distinct alerts and issue formatting.

* **Documentation**
  * Added setup instructions for managing priority companies and configuring alert webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->