### PR TITLE
feat: persist selected tab state using localStorage

### DIFF
--- a/webapp/components/JobsClient.tsx
+++ b/webapp/components/JobsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import type { ListingsData, ProcessedRow } from '@/lib/listings';
 
 type TabKey = 'summer' | 'offcycle' | 'newgrad';
@@ -159,8 +159,20 @@ function JobTable({
 }
 
 export default function JobsClient({ data }: { data: ListingsData }) {
-  const [activeTab, setActiveTab] = useState<TabKey>('summer');
+  const [activeTab, setActiveTabState] = useState<TabKey>('summer');
   const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('activeTab') as TabKey;
+    if (saved === 'summer' || saved === 'offcycle' || saved === 'newgrad') {
+      setActiveTabState(saved);
+    }
+  }, []);
+
+  const setActiveTab = (tab: TabKey) => {
+    setActiveTabState(tab);
+    localStorage.setItem('activeTab', tab);
+  };
 
   const tabs: TabKey[] = ['summer', 'offcycle', 'newgrad'];
 


### PR DESCRIPTION
Uses localStorage to remember the selected tab across page reloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Jobs page now remembers the selected tab between visits.
  * Previously selected tabs are restored automatically when the page loads.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->